### PR TITLE
PluginManager.loadPlugins()

### DIFF
--- a/src/main/java/org/bukkit/plugin/PluginManager.java
+++ b/src/main/java/org/bukkit/plugin/PluginManager.java
@@ -83,6 +83,15 @@ public interface PluginManager {
     public Plugin[] loadPlugins(File directory);
 
     /**
+     * Loads the array of plugins
+     *
+     * @param files Array of plugin files to load
+     * @param sourceFolder Containing folder path name string for error messages
+     * @return A list of all plugins loaded
+     */
+    public Plugin[] loadPlugins(File[] files, String sourceFolder);
+
+    /**
      * Disables all the loaded plugins
      */
     public void disablePlugins();

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -123,7 +123,7 @@ public final class SimplePluginManager implements PluginManager {
      *
      * @param files Array of plugin files to load
      * @param sourceFolder Containing folder path name string for error messages
-     * @return
+     * @return A list of all plugins loaded
      */
     public Plugin[] loadPlugins(File[] files, String sourceFolder) {
         List<Plugin> result = new ArrayList<Plugin>();


### PR DESCRIPTION
**Glowstone++** uses `SimplePluginManager`. I would like to make it possible to use other plugin managers in a clean way, but the existing `PluginManager` interface misses this method signature, making it impossible to abstract the plugin manager.
