### PR TITLE
SpawnMeta API for new NBT structure of Spawn Eggs.

### DIFF
--- a/src/main/java/org/bukkit/inventory/meta/SpawnMeta.java
+++ b/src/main/java/org/bukkit/inventory/meta/SpawnMeta.java
@@ -1,0 +1,29 @@
+package org.bukkit.inventory.meta;
+
+import org.bukkit.entity.EntityType;
+
+public interface SpawnMeta extends ItemMeta {
+
+    /**
+     * Checks if an Entity type is attributed to the spawn egg.
+     *
+     * @return true if an Entity type is attributed to the spawn egg
+     */
+    boolean hasEntityType();
+
+    /**
+     * Gets the Entity type attributed to the spawn egg.
+     *
+     * @return The entity type attributed to the spawn egg
+     */
+    EntityType getEntityType();
+
+    /**
+     * Sets the Entity type attributed to the spawn egg.
+     *
+     * @param type The Entity type to attribute to the spawn egg
+     */
+    void setEntityType(EntityType type);
+
+    SpawnMeta clone();
+}


### PR DESCRIPTION
1.9 changed the way Entity types are attributed to Spawn Eggs: instead of relying on durability, it uses NBT tags. See [Glowstone++ Issue 228](https://github.com/GlowstoneMC/GlowstonePlusPlus/issues/228) for details.
