### PR TITLE
Fixes Glowstone++ Issue 247

### DIFF
--- a/src/main/java/org/bukkit/Material.java
+++ b/src/main/java/org/bukkit/Material.java
@@ -36,7 +36,7 @@ public enum Material {
     COAL_ORE(16),
     LOG(17, Tree.class),
     LEAVES(18, Leaves.class),
-    SPONGE(19),
+    SPONGE(19, Sponge.class),
     GLASS(20),
     LAPIS_ORE(21),
     LAPIS_BLOCK(22),


### PR DESCRIPTION
I added the missing MaterialData link for Sponge in Glowkit. 

This fixes Glowstone++ Issue [#247](https://github.com/GlowstoneMC/GlowstonePlusPlus/issues/247).
